### PR TITLE
feat: support sweeping all types of rewards in one shot, cleanup all-UI

### DIFF
--- a/web/src/components/ClaimSlider.js
+++ b/web/src/components/ClaimSlider.js
@@ -1,0 +1,52 @@
+import { ethers } from "ethers";
+import { FormHelperText, Slider, Stack, Typography } from "@mui/material";
+import CurrencyValue from "./CurrencyValue";
+
+export default function ClaimSlider({
+  sx,
+  stakeAmountRpl,
+  totalRpl,
+  onSetStakeAmountRpl,
+  sliderProps = {},
+  caption = "and stake",
+}) {
+  let stakeAmountRplF = Number(ethers.utils.formatUnits(stakeAmountRpl));
+  let maxStakeAmountRplF = Number(ethers.utils.formatUnits(totalRpl));
+  return (
+    <Stack sx={sx} direction="column" justifyContent="space-between">
+      <Slider
+        value={stakeAmountRplF}
+        color="rpl"
+        valueLabelDisplay="off"
+        onChange={(e) =>
+          onSetStakeAmountRpl(
+            e.target.value >= maxStakeAmountRplF
+              ? totalRpl
+              : ethers.utils.parseUnits(String(e.target.value))
+          )
+        }
+        slotProps={{
+          root: {
+            style: {
+              padding: "8px 0px",
+            },
+          },
+        }}
+        min={0}
+        max={maxStakeAmountRplF}
+        {...sliderProps}
+      />
+      <Stack direction="row" alignItems="baseline" spacing={1}>
+        <FormHelperText sx={{ m: 0 }}>{caption}</FormHelperText>
+        <Typography variant="default">
+          <CurrencyValue
+            placeholder="0"
+            value={stakeAmountRpl}
+            size="xsmall"
+            currency="rpl"
+          />
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+}

--- a/web/src/components/DistributeEfficiencyAlert.js
+++ b/web/src/components/DistributeEfficiencyAlert.js
@@ -10,26 +10,43 @@ import useGasPrice from "../hooks/useGasPrice";
 import CurrencyValue from "./CurrencyValue";
 
 export default function DistributeEfficiencyAlert({
+  icon,
   gasAmount,
   nodeTotal,
+  severity = undefined,
   hideMessage,
 }) {
   const gasPrice = useGasPrice();
   const estGas = gasPrice.mul(gasAmount);
   const estReceipt = nodeTotal.sub(estGas);
-  const efficiencyPer = estReceipt.isNegative()
-    ? 0
-    : estReceipt
-        .mul(10000)
-        .div(nodeTotal.isZero() ? 1 : nodeTotal)
-        .toNumber() / 100;
-  const efficiencySeverity =
-    efficiencyPer > 99 ? "success" : efficiencyPer > 95 ? "warning" : "error";
+  const efficiencyPer =
+    estReceipt.isNegative() || nodeTotal.isZero()
+      ? 0
+      : estReceipt.mul(10000).div(nodeTotal).toNumber() / 100;
+  const efficiencySeverity = severity
+    ? severity
+    : efficiencyPer > 95
+    ? "success"
+    : efficiencyPer > 85
+    ? "warning"
+    : "error";
+  const title = estGas.isZero()
+    ? "--.--"
+    : `${efficiencyPer.toFixed(2)}% Efficiency`;
+  const message =
+    efficiencySeverity === "success"
+      ? ""
+      : "Consider waiting for lower gas prices or a larger balance.";
   return (
     <Tooltip
       arrow
       title={
-        <Stack direction="column" alignItems="center" sx={{ p: 1, width: 250 }}>
+        <Stack
+          direction="column"
+          spacing={1}
+          alignItems="center"
+          sx={{ p: 1, width: 250 }}
+        >
           <Typography color="text.secondary" variant="caption">
             Amount received after gas costs
           </Typography>
@@ -38,19 +55,27 @@ export default function DistributeEfficiencyAlert({
             divided by the distribution total
           </Typography>
           <CurrencyValue size="small" value={nodeTotal} currency="eth" />
+          <Typography sx={{ pt: 3 }} color="text.secondary" variant="caption">
+            This is just a rough ETH metric to help decide when to execute.
+          </Typography>
         </Stack>
       }
     >
       <Box>
         <Alert
+          icon={icon}
           style={{ cursor: "help" }}
           sx={{ opacity: 0.9 }}
           severity={efficiencySeverity}
         >
-          <AlertTitle>{efficiencyPer.toFixed(2)}% Efficiency</AlertTitle>
-          {!!hideMessage || efficiencySeverity === "success"
-            ? ""
-            : "Consider waiting for lower gas prices or a larger balance."}
+          {hideMessage || !message ? (
+            <>{title}</>
+          ) : (
+            <>
+              <AlertTitle>{title}</AlertTitle>
+              {message}
+            </>
+          )}
         </Alert>
       </Box>
     </Tooltip>

--- a/web/src/components/GasInfoFooter.js
+++ b/web/src/components/GasInfoFooter.js
@@ -1,43 +1,47 @@
-import {
-  FormHelperText,
-  Grid,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { Grid, Stack, Tooltip, Typography } from "@mui/material";
 import { trimValue } from "../utils";
 import { ethers } from "ethers";
 import useGasPrice from "../hooks/useGasPrice";
 import CurrencyValue from "./CurrencyValue";
 
-export default function GasInfoFooter({ sx, gasAmount }) {
+export function GasInfo({
+  sx,
+  size = "small",
+  gasAmount = ethers.constants.Zero,
+}) {
   const gasPrice = useGasPrice();
   const estGas = gasPrice.mul(gasAmount);
   return (
+    <Tooltip
+      title={`~${gasAmount.toNumber().toLocaleString()} gas`}
+      sx={{ cursor: "help", ...sx }}
+    >
+      <Stack direction="column">
+        <CurrencyValue value={estGas.mul(-1)} currency="eth" size={size} />
+        <Typography variant="caption" color="text.disabled">
+          gas @
+          <Typography
+            sx={{ pl: 1, pr: 0.5 }}
+            variant="inherit"
+            component="span"
+            color="white"
+          >
+            {trimValue(ethers.utils.formatUnits(gasPrice, "gwei"), {
+              maxDecimals: 0,
+            })}
+          </Typography>
+          gwei
+        </Typography>
+      </Stack>
+    </Tooltip>
+  );
+}
+
+export default function GasInfoFooter({ sx, gasAmount }) {
+  return (
     <Grid container sx={sx}>
       <Grid item xs={6}>
-        <Tooltip
-          title={`~${gasAmount.toNumber().toLocaleString()} gas`}
-          sx={{ cursor: "help" }}
-        >
-          <Stack direction="column">
-            <CurrencyValue value={estGas.mul(-1)} currency="eth" size="small" />
-            <FormHelperText sx={{ m: 0 }}>
-              gas @
-              <Typography
-                sx={{ pl: 1, pr: 0.5 }}
-                variant="inherit"
-                component="span"
-                color="white"
-              >
-                {trimValue(ethers.utils.formatUnits(gasPrice, "gwei"), {
-                  maxDecimals: 0,
-                })}
-              </Typography>
-              gwei
-            </FormHelperText>
-          </Stack>
-        </Tooltip>
+        <GasInfo gasAmount={gasAmount} />
       </Grid>
       <Grid item xs={6}>
         {/* TODO: show typical gas price range, maybe use fast-gas-gwei.data.eth */}

--- a/web/src/components/NodeContinuousRewardsTable.js
+++ b/web/src/components/NodeContinuousRewardsTable.js
@@ -10,7 +10,7 @@ import {
   Stack,
   Tooltip,
 } from "@mui/material";
-import { OpenInNew, Warning } from "@mui/icons-material";
+import { OpenInNew } from "@mui/icons-material";
 import { ethers } from "ethers";
 import {
   useContract,
@@ -68,8 +68,8 @@ const MINIPOOL_COLS = [
   },
   {
     field: "distribute",
-    headerName: "",
-    width: 150,
+    headerName: "Skimming etc",
+    width: 125,
     sortable: false,
     renderCell: ({ row }) => {
       let balance = ethers.BigNumber.from(row.balance || "0");
@@ -187,7 +187,6 @@ function DistributeButton({
   upgraded,
 }) {
   let canWithdraw = useCanConnectedAccountWithdraw(nodeAddress);
-  let hasLowBalance = nodeBalance.lt(ethers.utils.parseEther("0.4"));
   let hasTooHighBalance = balance.gt(ethers.utils.parseEther("8"));
   let disabled = !upgraded || !canWithdraw || hasTooHighBalance; // over 8 ETH you cannot skim rewards.
   const prep = usePrepareContractWrite({
@@ -247,7 +246,6 @@ function DistributeButton({
               color: theme.palette.gray.main,
             },
           })}
-          endIcon={hasLowBalance ? <Warning /> : null}
         >
           Distribute
         </Button>

--- a/web/src/components/NodeRewardsSummaryCard.js
+++ b/web/src/components/NodeRewardsSummaryCard.js
@@ -293,7 +293,7 @@ function ContinuousRewardsCard({ nodeAddress }) {
                   onMouseEnter={() => setHighlighted("consensus")}
                   onMouseLeave={() => setHighlighted("")}
                 >
-                  Consensus (skimming etc)
+                  Consensus (skimming)
                 </FormHelperText>
                 <ContinuousRewardRow
                   to="You"
@@ -372,14 +372,13 @@ function usePeriodicRewards({ nodeAddress }) {
   return { unclaimed, unclaimedEthTotal, unclaimedRplTotal };
 }
 
-const oneHundred = ethers.utils.parseUnits("100");
+const ten = ethers.utils.parseUnits("10");
 function SummaryCardContent({ nodeAddress, size = "large" }) {
   const periodic = usePeriodicRewards({ nodeAddress });
   const continuous = useNodeContinuousRewards({ nodeAddress });
   const ethTotal = continuous.nodeTotal?.add(periodic.unclaimedEthTotal);
   const rplTotal = periodic.unclaimedRplTotal;
-  let fontSize =
-    ethTotal?.gt(oneHundred) || rplTotal?.gt(oneHundred) ? "medium" : "large";
+  let fontSize = ethTotal?.gt(ten) || rplTotal?.gt(ten) ? "medium" : "large";
   let unupgradedMps = continuous?.minipools?.filter(
     ({ upgraded }) => upgraded === false
   );

--- a/web/src/components/SafeSweepCard.js
+++ b/web/src/components/SafeSweepCard.js
@@ -1,30 +1,32 @@
 import {
   Alert,
   AlertTitle,
-  Badge,
-  Box,
   Button,
   Card,
-  CardActionArea,
   CardContent,
-  CardHeader,
+  Checkbox,
   Chip,
+  FormControlLabel,
   FormHelperText,
   Grid,
   Link,
+  Paper,
   Slider,
   Stack,
   Tooltip,
   Typography,
 } from "@mui/material";
 import {
+  Add,
   ExpandLess,
   ExpandMore,
   HelpOutline,
+  Merge,
   OpenInNew,
+  Tune,
 } from "@mui/icons-material";
 import _ from "lodash";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ethers } from "ethers";
 import { useAccount } from "wagmi";
 import SafeAppsSDK from "@safe-global/safe-apps-sdk";
@@ -33,182 +35,218 @@ import {
   bnSum,
   delegateUpgradeEncoded,
   distributeBalanceEncoded,
-  estimateDistributeBatchGas,
+  distributeEncoded,
+  estimateClaimIntervalsGas,
+  estimateDistributeConsensusBatchGas,
+  estimateTipsMevGas,
   MinipoolStatus,
-  rocketscanUrl,
   safeAppUrl,
-  shortenAddress,
-  trimValue,
 } from "../utils";
-import useK from "../hooks/useK";
 import useCouldBeSafeContract from "../hooks/useCouldBeSafeContract";
 import useMinipoolDetails from "../hooks/useMinipoolDetails";
 import SafeIcon from "./SafeIcon";
-import GasInfoFooter from "./GasInfoFooter";
+import { GasInfo } from "./GasInfoFooter";
 import DistributeEfficiencyAlert from "./DistributeEfficiencyAlert";
 import useGasPrice from "../hooks/useGasPrice";
 import CurrencyValue from "./CurrencyValue";
+import useCanConnectedAccountWithdraw from "../hooks/useCanConnectedAccountWithdraw";
+import useNodeContinuousRewards from "../hooks/useNodeContinuousRewards";
+import ClaimSlider from "./ClaimSlider";
+import useNodeFinalizedRewardSnapshots from "../hooks/useNodeFinalizedRewardSnapshots";
+import contracts from "../contracts";
+import useNodeDetails from "../hooks/useNodeDetails";
+import { ClaimButtonTooltip } from "./ClaimAndStakeForm";
 
-function ConfigurationCard({
+function ConsensusConfigurationCard({
   sx,
+  isDistributingConsensus,
+  onDistributingConsensusChanged,
   batchSize,
   onBatchSize,
   ethThreshold,
   onEthThreshold,
+  minipoolCount,
+  disabled = false,
+  calculatedBatchAmount = ethers.constants.Zero,
+  calculatedMinipoolCount = 0,
 }) {
   return (
-    <Grid container sx={sx} rowSpacing={4} columnSpacing={2}>
-      <Grid item xs={6} sx={{ textAlign: "right" }}>
-        <Typography variant={"h6"} color={"text.primary"}>
-          Threshold
-        </Typography>
-        <Typography variant={"caption"} color={"text.secondary"}>
-          Minimum minipool ETH
-          <br />
-          balance to distribute
-        </Typography>
+    <Grid
+      sx={sx}
+      container
+      rowSpacing={1}
+      columnSpacing={2}
+      alignItems="center"
+    >
+      <Grid item xs={5} sx={{ textAlign: "right" }}>
+        <Tooltip
+          arrow
+          sx={{ cursor: "help" }}
+          title="Distribute beacon chain rewards that have accumulated in your minipools."
+        >
+          <Stack
+            direction={"row"}
+            spacing={1}
+            justifyContent="end"
+            alignItems={"center"}
+          >
+            <HelpOutline fontSize="inherit" color="disabled" />
+            <Typography color={"text.primary"} variant={"subtitle2"}>
+              Consensus
+            </Typography>
+          </Stack>
+        </Tooltip>
       </Grid>
-      <Grid item xs={6}>
-        <Slider
-          valueLabelDisplay="on"
-          value={Number(ethThreshold)}
-          onChange={(e) => onEthThreshold(String(e.target.value))}
-          min={0}
-          step={0.01}
-          max={1.5}
+      <Grid item xs={7}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              disabled={disabled}
+              checked={isDistributingConsensus}
+              onChange={(e) => onDistributingConsensusChanged(e.target.checked)}
+            />
+          }
+          color="text.secondary"
+          slotProps={{
+            typography: {
+              variant: "caption",
+              color: "text.secondary",
+            },
+          }}
+          disableTypography
+          label={
+            <Stack direction="column">
+              <Stack direction="row" spacing={1}>
+                <CurrencyValue
+                  size="xsmall"
+                  value={calculatedBatchAmount}
+                  currency="eth"
+                />
+              </Stack>
+              <FormHelperText sx={{ m: 0 }}>
+                {isDistributingConsensus ? "Distributing" : "Not Distributing"}
+              </FormHelperText>
+            </Stack>
+          }
         />
       </Grid>
-      <Grid item xs={6} sx={{ textAlign: "right" }}>
-        <Typography variant={"h6"} color={"text.primary"}>
-          Batch Size
-        </Typography>
-        <Typography variant={"caption"} color={"text.secondary"}>
-          Maximum minipools to
-          <br />
-          distribute in a batch
-        </Typography>
-      </Grid>
-      <Grid item xs={6}>
-        <Slider
-          valueLabelDisplay="on"
-          value={batchSize}
-          onChange={(e) => onBatchSize(e.target.value)}
-          min={1}
-          step={1}
-          max={200}
-        />
-      </Grid>
+      {!isDistributingConsensus ? null : (
+        <>
+          <Grid item xs={6} sx={{ textAlign: "right" }}>
+            <Tooltip
+              arrow
+              sx={{ cursor: "help" }}
+              title="Exclude minipools with ETH balance less than this amount"
+            >
+              <Stack
+                direction={"row"}
+                spacing={1}
+                justifyContent="end"
+                alignItems={"center"}
+              >
+                <HelpOutline fontSize="inherit" color="disabled" />
+                <Typography color={"text.primary"} variant={"subtitle2"}>
+                  Threshold
+                </Typography>
+              </Stack>
+            </Tooltip>
+          </Grid>
+          <Grid item xs={6}>
+            <Stack direction="row" alignItems="center" spacing={1.5}>
+              <Chip
+                size="small"
+                sx={{ width: 70 }}
+                label={Number(ethThreshold).toFixed(2)}
+              />
+              <Slider
+                size="small"
+                valueLabelDisplay="off"
+                value={Number(ethThreshold)}
+                onChange={(e) => onEthThreshold(String(e.target.value))}
+                min={0}
+                step={0.01}
+                max={0.5}
+              />
+            </Stack>
+          </Grid>
+          <Grid item xs={6} sx={{ textAlign: "right" }}>
+            <Tooltip
+              arrow
+              sx={{ cursor: "help" }}
+              title="Limit the batch to this many minipools (larger balances are selected first)"
+            >
+              <Stack
+                direction={"row"}
+                spacing={1}
+                justifyContent="end"
+                alignItems={"center"}
+              >
+                <HelpOutline fontSize="inherit" color="disabled" />
+                <Typography color={"text.primary"} variant={"subtitle2"}>
+                  Batch Size
+                </Typography>
+              </Stack>
+            </Tooltip>
+          </Grid>
+          <Grid item xs={6}>
+            <Stack direction="row" alignItems="center" spacing={1.5}>
+              <Chip size="small" sx={{ width: 70 }} label={batchSize} />
+              <Slider
+                size="small"
+                valueLabelDisplay="off"
+                value={batchSize}
+                onChange={(e) => onBatchSize(e.target.value)}
+                min={1}
+                step={1}
+                max={Math.min(200, minipoolCount)}
+              />
+            </Stack>
+          </Grid>
+        </>
+      )}
     </Grid>
   );
 }
 
-function BatchCard({ batch, upNext, readOnly }) {
-  let [isShowing, setShowing] = useState(false);
+function ReceiptsInfo({
+  sx,
+  size = "small",
+  amountEth = ethers.constants.Zero,
+  amountRpl,
+  amountGas,
+}) {
   const gasPrice = useGasPrice();
-  let nodeTotal = bnSum(batch.map(({ nodeBalance }) => nodeBalance));
-  let gasAmount = estimateDistributeBatchGas(batch.length);
-  const estGas = gasPrice.mul(gasAmount);
-  const submitBatch = async (batch) => {
-    let sdk = new SafeAppsSDK();
-    let txs = batch.map(({ minipoolAddress }) => ({
-      operation: "0x00",
-      to: minipoolAddress,
-      value: "0",
-      data: distributeBalanceEncoded,
-    }));
-    return sdk.txs.send({
-      txs,
-    });
-  };
+  const gasCostEth = gasPrice.mul(amountGas);
   return (
-    <Badge
-      sx={{ width: "100%" }}
-      badgeContent={batch.length}
-      color="primary"
-      max={999}
+    <Stack
+      sx={sx}
+      direction="row"
+      alignItems="baseline"
+      justifyContent="space-between"
     >
-      <Card sx={{ width: "100%" }} variant="outlined">
-        <CardContent>
-          <Stack direction="column" sx={{ m: 1 }}>
-            <Stack direction="column" spacing={0} sx={{ m: 0, mb: 2 }}>
-              <Stack
-                direction="row"
-                alignItems="baseline"
-                justifyContent="space-between"
-              >
-                <CurrencyValue
-                  value={nodeTotal.sub(estGas)}
-                  currency="eth"
-                  placeholder="0"
-                />
-              </Stack>
-              <FormHelperText sx={{ m: 0 }}>
-                approximate receipts (after gas)
-              </FormHelperText>
-            </Stack>
-            <DistributeEfficiencyAlert
-              gasAmount={gasAmount}
-              nodeTotal={nodeTotal}
-              hideMessage={!upNext}
+      <Stack direction="column">
+        <Stack direction="row" spacing={1} justifyContent="space-between">
+          <CurrencyValue
+            value={amountEth.sub(gasCostEth)}
+            currency="eth"
+            placeholder="0"
+            size={size}
+          />
+          {!amountRpl ? null : (
+            <CurrencyValue
+              value={amountRpl}
+              currency="rpl"
+              placeholder="0"
+              size={size}
             />
-            <GasInfoFooter sx={{ mt: 2 }} gasAmount={gasAmount} />
-          </Stack>
-          {upNext && (
-            <Box sx={readOnly ? { cursor: "not-allowed" } : {}}>
-              <Button
-                onClick={() =>
-                  submitBatch(batch)
-                    .then((res) => console.log("res", res))
-                    .catch((err) => console.log("err", err))
-                }
-                disabled={readOnly}
-                variant="contained"
-                sx={{ mt: 1, mb: 1 }}
-                fullWidth
-              >
-                Execute
-              </Button>
-            </Box>
           )}
-          <Button
-            sx={{ mt: 1 }}
-            fullWidth
-            color={"inherit"}
-            onClick={() => setShowing(!isShowing)}
-            endIcon={isShowing ? <ExpandLess /> : <ExpandMore />}
-          >
-            {batch.length} minipools
-          </Button>
-          {isShowing && (
-            <Grid sx={{ mt: 2 }} container columnSpacing={1}>
-              {batch.map(({ minipoolAddress, balance }) => (
-                <>
-                  <Grid key={`mp-${minipoolAddress}-rscan`} item xs={6}>
-                    <Chip
-                      size="small"
-                      variant="outlined"
-                      color="primary"
-                      clickable
-                      component="a"
-                      target="_blank"
-                      href={rocketscanUrl({ minipool: minipoolAddress })}
-                      label={shortenAddress(minipoolAddress)}
-                    />
-                  </Grid>
-                  <Grid key={`mp-${minipoolAddress}-balance`} item xs={6}>
-                    {trimValue(
-                      ethers.utils.formatUnits(
-                        ethers.BigNumber.from(balance || "0")
-                      )
-                    )}
-                  </Grid>
-                </>
-              ))}
-            </Grid>
-          )}
-        </CardContent>
-      </Card>
-    </Badge>
+        </Stack>
+        <Typography variant="caption" color="text.disabled">
+          receipts (after gas)
+        </Typography>
+      </Stack>
+      <GasInfo size={size} gasAmount={amountGas} />
+    </Stack>
   );
 }
 
@@ -221,45 +259,10 @@ function useSortedMinipoolDetails(nodeAddress) {
     .value();
 }
 
-function SafeAlert({ sx, label, nodeAddress, safeAddress }) {
-  let { connector } = useAccount();
-  if (connector?.id === "safe") {
-    // No alert when it is already open as a Safe app.
-    return null;
-  }
-  return (
-    <Card sx={sx} elevation={8} square>
-      <CardActionArea href={safeAppUrl({ safeAddress })} target="_blank">
-        <CardHeader
-          avatar={<SafeIcon color="primary" size={"medium"} />}
-          title={"Open as Safe App"}
-          subheader={`${label} address`}
-          action={<OpenInNew color="primary" sx={{ mt: 1.5, mr: 1.5 }} />}
-        />
-      </CardActionArea>
-    </Card>
-  );
-}
-
-function SweepCardContent({ sx, nodeAddress }) {
-  let { address, connector } = useAccount();
-  let { data: withdrawalAddress } =
-    useK.RocketStorage.Read.getNodeWithdrawalAddress({
-      args: [nodeAddress],
-      enabled: !!nodeAddress,
-    });
-  let hasSafeWithdrawalAddress = useCouldBeSafeContract(withdrawalAddress);
-  let hasSafeNodeAddress = useCouldBeSafeContract(nodeAddress);
+function UnupgradedAlert({ sx, nodeAddress }) {
+  let { connector, address } = useAccount();
   let minipools = useSortedMinipoolDetails(nodeAddress);
-  let [isShowingMore, setShowingMore] = useState(false);
-  let [batchSize, setBatchSize] = useState(100);
-  let [ethThreshold, setEthThreshold] = useState("0.2");
-  let batches = _.chain(minipools)
-    .filter(({ status }) => status === MinipoolStatus.staking)
-    .filter(({ upgraded }) => upgraded)
-    .filter(({ balance }) => balance.gte(ethers.utils.parseEther(ethThreshold)))
-    .chunk(batchSize)
-    .value();
+  let withdrawalAddress = useNodeWithdrawalAddress(nodeAddress);
   let unupgradedMps = minipools.filter(({ upgraded }) => upgraded === false);
   const upgradeAll = async (unupgradedMps) => {
     let sdk = new SafeAppsSDK({
@@ -276,150 +279,844 @@ function SweepCardContent({ sx, nodeAddress }) {
       txs,
     });
   };
+  if (!unupgradedMps.length) {
+    return null;
+  }
   const isSafeConnected = connector?.id === "safe";
   const isNodeOrWithdrawalAddress =
     address === nodeAddress || address === withdrawalAddress;
   const canProposeBatches = isSafeConnected && isNodeOrWithdrawalAddress;
+  return (
+    <Alert
+      sx={{ mb: 4, maxWidth: 450 }}
+      severity={"info"}
+      action={
+        canProposeBatches && (
+          <Button
+            size={"small"}
+            variant={"contained"}
+            color={"info"}
+            onClick={() => upgradeAll(unupgradedMps)}
+          >
+            Upgrade
+          </Button>
+        )
+      }
+    >
+      <AlertTitle>
+        <Chip size="small" label={unupgradedMps.length} /> minipools need
+        upgrade
+      </AlertTitle>
+      You cannot distribute minipools that have not been upgraded.
+    </Alert>
+  );
+}
+
+function useNodeWithdrawalAddress(nodeAddress) {
+  let { data } = useNodeDetails({ nodeAddress });
+  return data?.withdrawalAddress;
+}
+
+function SafeAlert({ sx, nodeAddress }) {
+  let { connector } = useAccount();
+  let withdrawalAddress = useNodeWithdrawalAddress(nodeAddress);
+  let hasSafeWithdrawalAddress = useCouldBeSafeContract(withdrawalAddress);
+  let hasSafeNodeAddress = useCouldBeSafeContract(nodeAddress);
+  let safeAddress = hasSafeWithdrawalAddress
+    ? withdrawalAddress
+    : hasSafeNodeAddress
+    ? nodeAddress
+    : null;
+  if (!safeAddress) {
+    return (
+      <Alert severity="warning" sx={sx}>
+        Sweep requires the node or its withdrawal address to be a{" "}
+        <Link href="https://safe.global/" target="_blank">
+          Safe
+        </Link>
+      </Alert>
+    );
+  }
+  if (connector?.id === "safe") {
+    // No alert when it is already open as a Safe app.
+    return null;
+  }
+  return (
+    <Alert
+      severity="warning"
+      sx={sx}
+      size={"small"}
+      action={
+        <Button
+          variant="outlined"
+          size="small"
+          color="primary"
+          startIcon={<SafeIcon />}
+          endIcon={<OpenInNew />}
+          href={safeAppUrl({ safeAddress })}
+        >
+          Open
+        </Button>
+      }
+    >
+      Open as a Safe App to enable Sweep
+    </Alert>
+  );
+}
+
+function useSweeper({ nodeAddress }) {
+  let { data: details } = useNodeDetails({ nodeAddress });
+  let { feeDistributorAddress } = details || {};
+
+  // Intervals configuration
+  let finalized = useNodeFinalizedRewardSnapshots({ nodeAddress });
+  let unclaimed = _.filter(finalized, ({ isClaimed }) => !isClaimed);
+  let rewardIndexes = _.map(unclaimed, "rewardIndex");
+  let amountsEth = _.map(unclaimed, "smoothingPoolEth");
+  let merkleProofs = _.map(unclaimed, "merkleProof");
+  let amountsRpl = _.map(unclaimed, ({ collateralRpl, oracleDaoRpl }) =>
+    // TODO: consider moving this to useNodeFinalizedRewardSnapshots
+    ethers.BigNumber.from(collateralRpl || "0").add(
+      ethers.BigNumber.from(oracleDaoRpl || "0")
+    )
+  );
+  let totalEth = bnSum(amountsEth);
+  let totalRpl = bnSum(amountsRpl);
+  let [isClaimingInterval, setClaimingInterval] = useState(
+    !totalRpl.isZero() || !totalEth.isZero()
+  );
+  let [stakeAmountRpl, setStakeAmountRpl] = useState(totalRpl);
+  // If we get updated interval info (`totalRpl/Eth`) then we want to use it as default.
+  useEffect(
+    () => setClaimingInterval(!totalRpl.isZero() || !totalEth.isZero()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [totalEth.toString(), totalRpl.toString()]
+  );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => setStakeAmountRpl(totalRpl), [totalRpl.toString()]);
+
+  // Consensus configuration
+  let minipools = useSortedMinipoolDetails(nodeAddress);
+  let distributableMinipools = _.chain(minipools)
+    .filter(({ status }) => status === MinipoolStatus.staking)
+    .filter(({ upgraded }) => upgraded)
+    .filter(({ balance }) => balance.gt(ethers.constants.Zero))
+    .value();
+  let [isDistributingConsensus, setDistributingConsensus] = useState(
+    !!distributableMinipools.length
+  );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(
+    () => setDistributingConsensus(!!distributableMinipools.length),
+    [distributableMinipools.length]
+  );
+  let [batchSize, setBatchSize] = useState(minipools.length || 200);
+  let [ethThreshold, setEthThreshold] = useState("0");
+  let batches = _.chain(distributableMinipools)
+    .filter(({ balance }) => balance.gte(ethers.utils.parseEther(ethThreshold)))
+    .chunk(batchSize)
+    .value();
   let currentBatch = _.first(batches);
-  let moreBatches = _.tail(batches);
+  // let moreBatches = _.tail(batches);
+  let currentBatchAmount = bnSum(
+    (currentBatch || []).map(({ nodeBalance }) => nodeBalance)
+  );
+
+  // Execution configuration
+  let { executionNodeTotal } = useNodeContinuousRewards({ nodeAddress });
+  let [isDistributingTipsMev, setDistributingTipsMev] = useState(
+    !executionNodeTotal.isZero()
+  );
+  // If we get an updated `executionNodeTotal` later, we want to use it as the default.
+  useEffect(
+    () => setDistributingTipsMev(!executionNodeTotal.isZero()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [executionNodeTotal.toString()]
+  );
+
+  let beforeGas = {
+    intervalsEth: totalEth,
+    tipsMevEth: executionNodeTotal,
+    consensusEth: currentBatchAmount,
+  };
+  let callGas = ethers.BigNumber.from("21000");
+
+  let gas = {
+    intervals: estimateClaimIntervalsGas(
+      unclaimed.length,
+      stakeAmountRpl.isZero()
+    ),
+    tipsMev: estimateTipsMevGas(),
+    consensus: estimateDistributeConsensusBatchGas((currentBatch || []).length),
+  };
+  let overall = {
+    eth: bnSum([
+      isClaimingInterval ? beforeGas.intervalsEth : ethers.constants.Zero,
+      isDistributingTipsMev ? beforeGas.tipsMevEth : ethers.constants.Zero,
+      isDistributingConsensus ? beforeGas.consensusEth : ethers.constants.Zero,
+    ]),
+    rpl: isClaimingInterval
+      ? totalRpl.sub(stakeAmountRpl)
+      : ethers.constants.Zero,
+    gas: bnSum([
+      isClaimingInterval ? gas.intervals : ethers.constants.Zero,
+      isDistributingTipsMev ? gas.tipsMev : ethers.constants.Zero,
+      isDistributingConsensus ? gas.consensus : ethers.constants.Zero,
+    ]),
+  };
+  if (!overall.gas.isZero()) {
+    overall.gas = overall.gas.add(callGas);
+  }
+  let execute = async () => {
+    let sdk = new SafeAppsSDK();
+    let txs = [];
+    if (isClaimingInterval) {
+      let args = [
+        nodeAddress,
+        rewardIndexes,
+        amountsRpl,
+        amountsEth,
+        merkleProofs,
+        stakeAmountRpl,
+      ];
+      txs = txs.concat([
+        {
+          operation: "0x00",
+          to: contracts.RocketMerkleDistributorMainnet.address,
+          value: "0",
+          data: new ethers.utils.Interface(
+            contracts.RocketMerkleDistributorMainnet.abi
+          ).encodeFunctionData("claimAndStake", args),
+        },
+      ]);
+    }
+    if (isDistributingTipsMev) {
+      txs = txs.concat([
+        {
+          operation: "0x00",
+          to: feeDistributorAddress,
+          value: "0",
+          data: distributeEncoded,
+        },
+      ]);
+    }
+    if (isDistributingConsensus) {
+      txs = txs.concat(
+        currentBatch.map(({ minipoolAddress }) => ({
+          operation: "0x00",
+          to: minipoolAddress,
+          value: "0",
+          data: distributeBalanceEncoded,
+        }))
+      );
+    }
+    return sdk.txs.send({
+      txs,
+    });
+  };
+
+  return {
+    execute,
+    // Interval config
+    isClaimingInterval,
+    setClaimingInterval,
+    stakeAmountRpl,
+    setStakeAmountRpl,
+    // Interval derived values
+    totalEth,
+    totalRpl,
+    rewardIndexes,
+
+    // Consensus config
+    isDistributingConsensus,
+    setDistributingConsensus,
+    batchSize,
+    setBatchSize,
+    ethThreshold,
+    setEthThreshold,
+    // Consensus derived values
+    minipools,
+    distributableMinipools,
+    currentBatch,
+    currentBatchAmount,
+
+    // Execution config
+    isDistributingTipsMev,
+    setDistributingTipsMev,
+    executionNodeTotal,
+
+    // Analysis
+    beforeGas,
+    gas,
+    overall,
+  };
+}
+
+function SweepCardContent({ sx, nodeAddress, sweeper }) {
+  let canWithdraw = useCanConnectedAccountWithdraw(nodeAddress);
+  let {
+    isClaimingInterval,
+    setClaimingInterval,
+    stakeAmountRpl,
+    setStakeAmountRpl,
+    totalEth,
+    totalRpl,
+
+    isDistributingConsensus,
+    setDistributingConsensus,
+    batchSize,
+    setBatchSize,
+    ethThreshold,
+    setEthThreshold,
+    minipools,
+    currentBatch,
+    currentBatchAmount,
+
+    isDistributingTipsMev,
+    setDistributingTipsMev,
+
+    beforeGas,
+    gas,
+    overall,
+  } = sweeper;
   return (
     <CardContent sx={sx}>
-      <Stack direction="column" spacing={2}>
-        {!hasSafeWithdrawalAddress && !hasSafeNodeAddress && (
-          <Alert severity="warning">
-            Executing this requires the node or its withdrawal address to be a{" "}
-            <Link href="https://safe.global/" target="_blank">
-              Safe
-            </Link>
-          </Alert>
-        )}
-        {hasSafeNodeAddress && (
-          <SafeAlert
-            label="Node"
-            nodeAddress={nodeAddress}
-            safeAddress={nodeAddress}
-          />
-        )}
-        {hasSafeWithdrawalAddress && (
-          <SafeAlert
-            label="Withdrawal"
-            nodeAddress={nodeAddress}
-            safeAddress={withdrawalAddress}
-          />
-        )}
-        {unupgradedMps.length > 0 && (
-          <Alert
-            sx={{ maxWidth: 450 }}
-            severity={"info"}
-            action={
-              canProposeBatches && (
-                <Button
-                  size={"small"}
-                  variant={"contained"}
-                  color={"info"}
-                  onClick={() => upgradeAll(unupgradedMps)}
+      <Stack direction="column">
+        <TransactionRow
+          lhs={
+            <Grid
+              sx={{ pt: 0.5, pr: 3 }}
+              container
+              rowSpacing={2}
+              columnSpacing={2}
+              // alignItems="center"
+            >
+              <Grid item xs={5} sx={{ textAlign: "right" }}>
+                <Tooltip
+                  arrow
+                  sx={{ cursor: "help" }}
+                  title="Claim your periodic rewards. This includes inflation RPL and ETH for nodes in the smoothing pool."
                 >
-                  Upgrade
-                </Button>
-              )
-            }
-          >
-            <AlertTitle>
-              <Chip size="small" label={unupgradedMps.length} /> minipools need
-              upgrade
-            </AlertTitle>
-            You cannot distribute minipools that have not been upgraded.
-          </Alert>
-        )}
-        <Grid container>
-          <Grid item xs={12} sm={6} sx={{ pt: 5, pr: 4, pb: 4 }}>
-            <ConfigurationCard
+                  <Stack
+                    direction={"row"}
+                    spacing={1}
+                    sx={{ pt: 1, pb: 1 }}
+                    justifyContent="end"
+                    alignItems={"center"}
+                  >
+                    <HelpOutline fontSize="inherit" color="disabled" />
+                    <Typography color={"text.primary"} variant={"subtitle2"}>
+                      Intervals
+                    </Typography>
+                  </Stack>
+                </Tooltip>
+              </Grid>
+              <Grid item xs={7}>
+                <Stack direction="column">
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        // disabled={totalRpl.isZero() && totalEth.isZero()}
+                        checked={isClaimingInterval}
+                        onChange={(e) => setClaimingInterval(e.target.checked)}
+                      />
+                    }
+                    color="text.secondary"
+                    slotProps={{
+                      typography: {
+                        variant: "caption",
+                        color: "text.secondary",
+                      },
+                    }}
+                    disableTypography
+                    label={
+                      <Stack spacing={0} direction="column">
+                        <Stack direction="row" spacing={1}>
+                          <CurrencyValue
+                            size="xsmall"
+                            value={totalEth}
+                            currency="eth"
+                            placeholder="0"
+                          />
+                          {isClaimingInterval ? null : (
+                            <CurrencyValue
+                              size="xsmall"
+                              value={totalRpl}
+                              currency="rpl"
+                              // placeholder="0"
+                            />
+                          )}
+                        </Stack>
+                        <FormHelperText sx={{ m: 0 }}>
+                          {isClaimingInterval ? "Claiming" : "Not Claiming"}
+                        </FormHelperText>
+                      </Stack>
+                    }
+                  />
+                  {!isClaimingInterval || totalRpl.isZero() ? null : (
+                    <ClaimSlider
+                      sx={{ ml: 4 }}
+                      stakeAmountRpl={stakeAmountRpl}
+                      totalRpl={totalRpl}
+                      onSetStakeAmountRpl={setStakeAmountRpl}
+                      caption="staking"
+                      sliderProps={{
+                        size: "small",
+                        color: canWithdraw ? "rpl" : "gray",
+                        sx: {
+                          width: 124,
+                          pb: 0,
+                        },
+                      }}
+                    />
+                  )}
+                </Stack>
+              </Grid>
+            </Grid>
+          }
+          rhs={
+            <Stack direction="column" sx={{ pl: 2, pr: 2 }} spacing={2}>
+              {!isClaimingInterval ? null : (
+                <ReceiptsInfo
+                  amountEth={beforeGas.intervalsEth}
+                  amountGas={gas.intervals}
+                  amountRpl={totalRpl.sub(stakeAmountRpl)}
+                />
+              )}
+              <TransactionDescription
+                title={
+                  isClaimingInterval
+                    ? "Claim rewards (inflation, smoothing)"
+                    : "Don't claim rewards (inflation, smoothing)"
+                }
+              />
+            </Stack>
+          }
+        />
+        <IconRow Icon={Add} />
+        <TransactionRow
+          lhs={
+            <Grid
+              sx={{ pt: 0, pr: 3 }}
+              container
+              rowSpacing={2}
+              columnSpacing={2}
+              alignItems="center"
+            >
+              <Grid item xs={5} sx={{ textAlign: "right" }}>
+                <Tooltip
+                  arrow
+                  sx={{ cursor: "help" }}
+                  title="Distribute tips/MEV awareded to your validators. This will stay empty when you're in the smoothing pool."
+                >
+                  <Stack
+                    direction={"row"}
+                    spacing={1}
+                    justifyContent="end"
+                    alignItems={"center"}
+                  >
+                    <HelpOutline fontSize="inherit" color="disabled" />
+                    <Typography color={"text.primary"} variant={"subtitle2"}>
+                      Execution
+                    </Typography>
+                  </Stack>
+                </Tooltip>
+              </Grid>
+              <Grid item xs={7}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      // disabled={executionNodeTotal.isZero()}
+                      checked={isDistributingTipsMev}
+                      onChange={(e) => setDistributingTipsMev(e.target.checked)}
+                    />
+                  }
+                  color="text.secondary"
+                  slotProps={{
+                    typography: {
+                      variant: "caption",
+                      color: "text.secondary",
+                    },
+                  }}
+                  disableTypography
+                  label={
+                    <Stack spacing={0} direction="column">
+                      <CurrencyValue
+                        size="xsmall"
+                        value={beforeGas.tipsMevEth}
+                        currency="eth"
+                      />
+                      <FormHelperText sx={{ m: 0 }}>
+                        {isDistributingTipsMev
+                          ? "Distributing"
+                          : "Not Distributing"}
+                      </FormHelperText>
+                    </Stack>
+                  }
+                />
+              </Grid>
+            </Grid>
+          }
+          rhs={
+            <Stack direction="column" sx={{ pl: 2, pr: 2 }} spacing={2}>
+              {!isDistributingTipsMev ? null : (
+                <ReceiptsInfo
+                  amountEth={beforeGas.tipsMevEth}
+                  amountGas={gas.tipsMev}
+                />
+              )}
+              <TransactionDescription
+                title={
+                  isDistributingTipsMev
+                    ? "Distribute execution rewards (tips/MEV)"
+                    : "Don't distribute execution rewards (tips/MEV)"
+                }
+              />
+            </Stack>
+          }
+        />
+        <IconRow Icon={Add} />
+        <TransactionRow
+          lhs={
+            <ConsensusConfigurationCard
+              sx={{ pr: 3, pt: 0 }}
+              isDistributingConsensus={isDistributingConsensus}
+              onDistributingConsensusChanged={setDistributingConsensus}
+              // disabled={!distributableMinipools.length}
               batchSize={batchSize}
               ethThreshold={ethThreshold}
               onBatchSize={setBatchSize}
               onEthThreshold={setEthThreshold}
               minipoolCount={minipools.length}
+              calculatedMinipoolCount={currentBatch?.length || 0}
+              calculatedBatchAmount={currentBatchAmount}
             />
-          </Grid>
-          <Grid item xs={12} sm={6} sx={{ pr: 0.5 }}>
-            <Tooltip
-              title={`The next batch to distribute based on your configured Threshold and Batch Size.`}
-              sx={{ cursor: "help" }}
-            >
-              <Typography variant={"overline"} color={"text.secondary"}>
-                Current Batch <HelpOutline fontSize="inherit" />
-              </Typography>
-            </Tooltip>
-            {currentBatch && (
-              <BatchCard
-                key={"first-batch"}
-                batch={currentBatch}
-                upNext
-                readOnly={!canProposeBatches}
-                nodeAddress={nodeAddress}
+          }
+          rhs={
+            <Stack direction="column" sx={{ pl: 2, pr: 2 }} spacing={2}>
+              {!isDistributingConsensus || !currentBatch?.length ? null : (
+                <ReceiptsInfo
+                  amountEth={beforeGas.consensusEth}
+                  amountGas={gas.consensus}
+                />
+              )}
+              <TransactionDescription
+                title={
+                  !isDistributingConsensus || !currentBatch?.length ? (
+                    "Don't distribute any minipools (skimming etc)"
+                  ) : (
+                    <>
+                      Distribute{" "}
+                      <Chip
+                        size="small"
+                        label={
+                          !currentBatch?.length
+                            ? "0"
+                            : currentBatch?.length.toLocaleString()
+                        }
+                      />{" "}
+                      minipools (skimming)
+                    </>
+                  )
+                }
               />
-            )}
-            {currentBatch && moreBatches.length > 0 && (
-              <Button
-                sx={{ mt: 1 }}
-                fullWidth
-                color={"inherit"}
-                onClick={() => setShowingMore(!isShowingMore)}
-                endIcon={isShowingMore ? <ExpandLess /> : <ExpandMore />}
-              >
-                and {moreBatches.length} more{" "}
-                {moreBatches.length > 0 ? "batches" : "batch"}
-              </Button>
-            )}
-            {!currentBatch &&
-              (minipools.length > 0 ? (
-                minipools.length === unupgradedMps.length ? (
-                  <Alert severity="info">
-                    <AlertTitle>Upgrade required</AlertTitle>
-                    You cannot distribute minipools that have not been upgraded.
-                  </Alert>
-                ) : (
-                  <Alert severity="info">
-                    <AlertTitle>Below Threshold</AlertTitle>
-                    You should wait for more to accumulate in your minipools. Or
-                    you can lower the threshold to distribute smaller balances.
-                  </Alert>
-                )
-              ) : (
-                <Alert severity="info">No minipools found.</Alert>
-              ))}
-          </Grid>
-        </Grid>
-        {moreBatches.length > 0 && isShowingMore && (
-          <Stack direction="column">
-            <Typography variant={"overline"} color={"text.secondary"}>
-              Up Next - {moreBatches.length} more batches
-            </Typography>
-            <Grid container spacing={2}>
-              {moreBatches.map((batch, i) => (
-                <Grid key={`batch-${i}`} item xs={12} sm={4} sx={{ pr: 0.5 }}>
-                  <BatchCard
-                    batch={batch}
-                    upNext={false}
-                    readOnly={!canProposeBatches}
-                    ethThreshold={ethThreshold}
-                    nodeAddress={nodeAddress}
-                  />
-                </Grid>
-              ))}
-            </Grid>
-          </Stack>
-        )}
+            </Stack>
+          }
+        />
+        <IconRow
+          Icon={Merge}
+          iconProps={{
+            sx: {
+              transform: "rotate(180deg)",
+            },
+          }}
+        />
+        <TransactionRow
+          // elevation={0}
+          rhs={
+            <Stack direction="column" spacing={3} sx={{ pl: 2, pr: 2 }}>
+              <ReceiptsInfo
+                amountEth={overall.eth}
+                amountRpl={overall.rpl}
+                amountGas={overall.gas}
+              />
+              <DistributeEfficiencyAlert
+                gasAmount={overall.gas}
+                nodeTotal={overall.eth}
+                hideMessage
+              />
+            </Stack>
+          }
+        />
       </Stack>
     </CardContent>
   );
 }
 
-export default function SafeSweepCard({ sx, nodeAddress }) {
+function TransactionRow({ lhs, rhs, elevation = 2 }) {
   return (
-    <Card sx={sx}>
-      <CardHeader subheader="Distribute multiple minipools in a single transaction." />
-      <SweepCardContent nodeAddress={nodeAddress} />
-    </Card>
+    <Paper sx={{ pb: 1, pt: 1 }} elevation={elevation} square>
+      {/*<Typography variant="overline">Title</Typography>*/}
+      <Grid container columnSpacing={4} rowSpacing={2} alignItems="center">
+        <Grid item xs={12} sm={6}>
+          {lhs}
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          {rhs}
+        </Grid>
+      </Grid>
+    </Paper>
+  );
+}
+
+function TransactionDescription({ title }) {
+  return (
+    <Paper sx={{ textAlign: "center", fontSize: 11, p: 1 }} square>
+      {title}
+    </Paper>
+  );
+}
+
+function IconRow({ Icon, iconProps }) {
+  return (
+    <Grid container sx={{ p: 0, m: 0 }} alignItems="center">
+      <Grid item xs={12} sm={6} />
+      <Grid item xs={12} sm={6} sx={{ pt: 0.5, m: 0, textAlign: "center" }}>
+        <Icon fontSize="medium" color="disabled" {...iconProps} />
+      </Grid>
+    </Grid>
+  );
+}
+
+export default function SafeSweepCard({ sx, nodeAddress }) {
+  let { address, connector } = useAccount();
+  let [isCustomizing, setCustomizing] = useState(false);
+  let sweeper = useSweeper({ nodeAddress });
+  let {
+    execute,
+    isClaimingInterval,
+    isDistributingTipsMev,
+    isDistributingConsensus,
+    totalRpl,
+    totalEth,
+    rewardIndexes,
+    stakeAmountRpl,
+    setStakeAmountRpl,
+    currentBatch,
+    currentBatchAmount,
+    executionNodeTotal,
+    overall,
+  } = sweeper;
+  let withdrawalAddress = useNodeWithdrawalAddress(nodeAddress);
+  const isSafeConnected = connector?.id === "safe";
+  const isNodeOrWithdrawalAddress =
+    address === nodeAddress || address === withdrawalAddress;
+  let canWithdraw = isSafeConnected && isNodeOrWithdrawalAddress;
+  let color = canWithdraw ? "primary" : "gray";
+  return (
+    <Stack sx={sx} direction="column" spacing={2}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        sx={{ maxWidth: 700 }}
+        justifyContent="flex-start"
+      >
+        <Button
+          size="large"
+          sx={{ pl: 0, pr: 1.5, minWidth: 54 }}
+          color="gray"
+          onClick={() => setCustomizing(!isCustomizing)}
+        >
+          {isCustomizing ? (
+            <ExpandLess fontSize="inherit" />
+          ) : (
+            <ExpandMore fontSize="inherit" />
+          )}
+          <Tune fontSize="medium" />
+        </Button>
+        <Tooltip
+          arrow
+          // placement="bottom-start"
+          title={
+            <ClaimButtonTooltip
+              gasAmount={overall.gas}
+              ethTotal={overall.eth}
+              rplTotal={totalRpl}
+              stakeAmountRpl={stakeAmountRpl}
+            >
+              <Stack>
+                <Grid container columnSpacing={1} rowSpacing={0.5}>
+                  {!isClaimingInterval ? null : (
+                    <>
+                      <Grid item xs={4.5}>
+                        <Stack direction="row" justifyContent="flex-end">
+                          <Typography
+                            component="span"
+                            variant="caption"
+                            color="text.secondary"
+                          >
+                            <Typography
+                              component="span"
+                              variant="caption"
+                              color="text.primary"
+                            >
+                              {rewardIndexes?.length}
+                            </Typography>{" "}
+                            interval{rewardIndexes?.length === 1 ? "" : "s"}
+                          </Typography>
+                        </Stack>
+                      </Grid>
+                      <Grid item xs={7.5}>
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          justifyContent="flex-start"
+                        >
+                          <CurrencyValue
+                            size="xsmall"
+                            value={totalEth}
+                            currency="eth"
+                            placeholder="0"
+                          />
+                          <CurrencyValue
+                            size="xsmall"
+                            value={totalRpl}
+                            currency="rpl"
+                            placeholder="0"
+                          />
+                        </Stack>
+                      </Grid>
+                    </>
+                  )}
+                  {!isDistributingTipsMev ? null : (
+                    <>
+                      <Grid item xs={4.5}>
+                        <Stack direction="row" justifyContent="flex-end">
+                          <Typography
+                            component="span"
+                            variant="caption"
+                            color="text.secondary"
+                          >
+                            tips/MEV
+                          </Typography>
+                        </Stack>
+                      </Grid>
+                      <Grid item xs={7.5}>
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          justifyContent="flex-start"
+                        >
+                          <CurrencyValue
+                            size="xsmall"
+                            value={executionNodeTotal}
+                            currency="eth"
+                            placeholder="0"
+                          />
+                        </Stack>
+                      </Grid>
+                    </>
+                  )}
+                  {!isDistributingConsensus ? null : (
+                    <>
+                      <Grid item xs={4.5}>
+                        <Stack direction="row" justifyContent="flex-end">
+                          <Typography
+                            component="span"
+                            variant="caption"
+                            color="text.secondary"
+                          >
+                            <Typography
+                              component="span"
+                              variant="caption"
+                              color="text.primary"
+                            >
+                              {currentBatch?.length}
+                            </Typography>{" "}
+                            minipool{currentBatch?.length === 1 ? "" : "s"}
+                          </Typography>
+                        </Stack>
+                      </Grid>
+                      <Grid item xs={7.5}>
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          justifyContent="flex-start"
+                        >
+                          <CurrencyValue
+                            size="xsmall"
+                            value={currentBatchAmount}
+                            currency="eth"
+                            placeholder="0"
+                          />
+                        </Stack>
+                      </Grid>
+                    </>
+                  )}
+                </Grid>
+              </Stack>
+            </ClaimButtonTooltip>
+          }
+        >
+          <Stack
+            sx={{
+              cursor: canWithdraw ? undefined : "not-allowed",
+            }}
+            direction="row"
+            alignItems="center"
+          >
+            <Button
+              onClick={() =>
+                execute()
+                  .then((res) => console.log("res", res))
+                  .catch((err) => console.log("err", err))
+              }
+              sx={(theme) => ({
+                // maxWidth: 200,
+                mr: 1.5,
+                boxShadow: `0 0 5px ${theme.palette[color].light}`,
+              })}
+              size="medium"
+              variant="outlined"
+              color={color}
+              disabled={!canWithdraw}
+              endIcon={
+                <CurrencyValue
+                  value={overall.eth}
+                  size="xsmall"
+                  currency="eth"
+                  placeholder="0"
+                />
+              }
+            >
+              Sweep
+            </Button>
+            {!isClaimingInterval || totalRpl.isZero() ? null : (
+              <ClaimSlider
+                // sx={{ width: 150 }}
+                stakeAmountRpl={stakeAmountRpl}
+                totalRpl={totalRpl}
+                onSetStakeAmountRpl={setStakeAmountRpl}
+                sliderProps={{
+                  size: "small",
+                  color: canWithdraw ? "rpl" : "gray",
+                  sx: {
+                    width: 124,
+                    pb: 0,
+                  },
+                }}
+              />
+            )}
+          </Stack>
+        </Tooltip>
+      </Stack>
+      <SafeAlert sx={{ maxWidth: 700 }} nodeAddress={nodeAddress} />
+      <UnupgradedAlert sx={{ maxWidth: 700 }} nodeAddress={nodeAddress} />
+      {!isCustomizing ? null : (
+        <Card raised>
+          <SweepCardContent nodeAddress={nodeAddress} sweeper={sweeper} />
+        </Card>
+      )}
+    </Stack>
   );
 }


### PR DESCRIPTION
simple:
<img width="503" alt="Screenshot 2023-07-06 at 1 51 51 AM" src="https://github.com/dmccartney/rocketsweep/assets/599974/cefdd24c-2d7a-4f5e-8cad-a042deb05dd7">

expanded (customizing):
<img width="987" alt="Screenshot 2023-07-06 at 1 52 00 AM" src="https://github.com/dmccartney/rocketsweep/assets/599974/108af376-1d25-4ee6-8626-472e062f1424">
