### PR TITLE
Increase time for loading window

### DIFF
--- a/web/src/hooks/useMinipoolDetails.js
+++ b/web/src/hooks/useMinipoolDetails.js
@@ -18,7 +18,7 @@ export default function useMinipoolDetails(nodeAddress) {
   let mpDelegateInterface = new ethers.utils.Interface(
     contracts.RocketMinipoolDelegate.abi
   );
-  let loadingWindowMs = 15 * 1000;
+  let loadingWindowMs = 60 * 1000;
   let details = useQueries(
     minipoolAddresses.map((minipoolAddress, i) => ({
       queryKey: ["MinipoolDetails", minipoolAddress],


### PR DESCRIPTION
My rocketsweep is timing out when trying to load 66 pools at 77%, it looks like it's because of this check here for `>50`.

I increased loadingWindowMs here but not sure if that will solve anything...

I don't really see why it would fail, except perhaps if it's surpassing QueryClient's default timeout?

If that is the case we'll need to add an option to useQueries here for the timeout.