### PR TITLE
fix: check for array of addresses when prepping sweep

### DIFF
--- a/web/src/components/SafeSweepCard.js
+++ b/web/src/components/SafeSweepCard.js
@@ -41,6 +41,7 @@ import {
   estimateDistributeConsensusBatchGas,
   estimateFinalizeGas,
   estimateTipsMevGas,
+  firstOrOnly,
   MinipoolStatus,
   safeAppUrl,
 } from "../utils";
@@ -499,7 +500,7 @@ function useSweeper({ nodeAddress }) {
       txs = txs.concat([
         {
           operation: "0x00",
-          to: contracts.RocketMerkleDistributorMainnet.address,
+          to: firstOrOnly(contracts.RocketMerkleDistributorMainnet.address),
           value: "0",
           data: new ethers.utils.Interface(
             contracts.RocketMerkleDistributorMainnet.abi

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,6 +1,10 @@
 import { ethers } from "ethers";
 import _ from "lodash";
 
+export function firstOrOnly(arrayOrNot) {
+  return Array.isArray(arrayOrNot) ? arrayOrNot[0] : arrayOrNot;
+}
+
 // Trim the input address to be "0x####...####"
 export function shortenAddress(address, charCount = 4) {
   // .getAddress here ensures we're dealing with the checksum address


### PR DESCRIPTION
This properly supports an array of distributor addresses.
Part of #43 